### PR TITLE
feat: Create initial AetherLink FC Agent application

### DIFF
--- a/aetherlink-fc-agent/CMakeLists.txt
+++ b/aetherlink-fc-agent/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(AetherlinkFCAgent)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(MAVSDK REQUIRED)
+
+add_executable(fc_agent
+    src/main.cpp
+    src/MavlinkManager.cpp
+)
+
+target_link_libraries(fc_agent MAVSDK::mavsdk)

--- a/aetherlink-fc-agent/src/MavlinkManager.cpp
+++ b/aetherlink-fc-agent/src/MavlinkManager.cpp
@@ -1,0 +1,45 @@
+#include "MavlinkManager.h"
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+MavlinkManager::MavlinkManager() {}
+
+void MavlinkManager::connect_and_start() {
+    mavsdk::ConnectionResult connection_result;
+
+    std::cout << "Connecting to simulator..." << std::endl;
+    connection_result = _mavsdk.add_any_connection("udp://:14540");
+
+    if (connection_result != mavsdk::ConnectionResult::Success) {
+        std::cerr << "Connection failed: " << connection_result << std::endl;
+        return;
+    }
+
+    std::cout << "Waiting for system to be discovered..." << std::endl;
+    _mavsdk.subscribe_on_new_system([this]() {
+        const auto system = _mavsdk.systems().at(0);
+
+        if (system->is_connected()) {
+            _system = system;
+            std::cout << "System discovered!" << std::endl;
+
+            std::cout << "Subscribing to telemetry..." << std::endl;
+            auto telemetry = std::make_shared<mavsdk::Telemetry>(_system);
+
+            telemetry->subscribe_attitude([this](mavsdk::Telemetry::Attitude attitude) {
+                std::cout << "Attitude: "
+                          << "Roll(deg): " << attitude.roll_deg << ", "
+                          << "Pitch(deg): " << attitude.pitch_deg << ", "
+                          << "Yaw(deg): " << attitude.yaw_deg << std::endl;
+            });
+
+            telemetry->subscribe_position([this](mavsdk::Telemetry::Position position) {
+                std::cout << "Position: "
+                          << "Lat: " << position.latitude_deg << ", "
+                          << "Lon: " << position.longitude_deg << ", "
+                          << "Alt(m): " << position.relative_altitude_m << std::endl;
+            });
+        }
+    });
+}

--- a/aetherlink-fc-agent/src/MavlinkManager.h
+++ b/aetherlink-fc-agent/src/MavlinkManager.h
@@ -1,0 +1,18 @@
+#ifndef MAVLINK_MANAGER_H
+#define MAVLINK_MANAGER_H
+
+#include <mavsdk/mavsdk.h>
+#include <mavsdk/plugins/telemetry/telemetry.h>
+#include <memory>
+
+class MavlinkManager {
+public:
+    MavlinkManager();
+    void connect_and_start();
+
+private:
+    mavsdk::Mavsdk _mavsdk;
+    std::shared_ptr<mavsdk::System> _system;
+};
+
+#endif // MAVLINK_MANAGER_H

--- a/aetherlink-fc-agent/src/main.cpp
+++ b/aetherlink-fc-agent/src/main.cpp
@@ -1,0 +1,15 @@
+#include "MavlinkManager.h"
+#include <thread>
+#include <chrono>
+
+int main() {
+    MavlinkManager mavlink_manager;
+    mavlink_manager.connect_and_start();
+
+    // Keep the main thread alive
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This commit introduces the foundational C++ application for the AetherLink Flight Computer (FC) Agent.

It includes the following components:
- A `CMakeLists.txt` file to manage the build process and dependencies.
- A `MavlinkManager` class to encapsulate all MAVSDK-related logic, including connecting to a PX4 SITL simulation and subscribing to telemetry data.
- A `main.cpp` entry point to run the application.

The application is designed to connect to a simulator at `udp://:14540`, discover a MAVLink system, and print Attitude and Position telemetry to the console.

Note: The project could not be built and tested in the development environment due to limitations in installing the MAVSDK dependency. The code is expected to build correctly in an environment where MAVSDK is available.