### PR TITLE
Fix telemetry stream by extending Telemetry object lifetime

### DIFF
--- a/aetherlink-fc-agent/src/MavlinkManager.cpp
+++ b/aetherlink-fc-agent/src/MavlinkManager.cpp
@@ -28,16 +28,16 @@ void MavlinkManager::connect_and_start() {
     _mavsdk->subscribe_on_new_system([this]() {
         std::cout << "Discovered a new system\n";
         _system = _mavsdk->systems().front();
-        auto telemetry = std::make_shared<mavsdk::Telemetry>(_system);
+        _telemetry = std::make_shared<mavsdk::Telemetry>(_system);
 
-        telemetry->subscribe_attitude_euler([this](mavsdk::Telemetry::EulerAngle angle) {
+        _telemetry->subscribe_attitude_euler([this](mavsdk::Telemetry::EulerAngle angle) {
             std::cout << "Attitude: "
                       << "Roll(deg): " << angle.roll_deg << ", "
                       << "Pitch(deg): " << angle.pitch_deg << ", "
                       << "Yaw(deg): " << angle.yaw_deg << std::endl;
         });
 
-        telemetry->subscribe_position([this](mavsdk::Telemetry::Position position) {
+        _telemetry->subscribe_position([this](mavsdk::Telemetry::Position position) {
             std::cout << "Position: "
                       << "Lat: " << position.latitude_deg << ", "
                       << "Lon: " << position.longitude_deg << ", "

--- a/aetherlink-fc-agent/src/MavlinkManager.h
+++ b/aetherlink-fc-agent/src/MavlinkManager.h
@@ -13,6 +13,7 @@ public:
 private:
     std::unique_ptr<mavsdk::Mavsdk> _mavsdk;
     std::shared_ptr<mavsdk::System> _system;
+    std::shared_ptr<mavsdk::Telemetry> _telemetry;
 };
 
 #endif // MAVLINK_MANAGER_H


### PR DESCRIPTION
The telemetry data stream was stopping shortly after the connection was established. This was because the `Telemetry` object, which managed the data subscriptions, was created as a local variable inside a lambda. When the lambda finished executing, the `Telemetry` object was destroyed, and its destructor cancelled the subscriptions.

This fix moves the `Telemetry` object from a local variable to a member of the `MavlinkManager` class. By making it a `std::shared_ptr` member, its lifetime is now tied to the `MavlinkManager` instance, ensuring that the telemetry subscriptions remain active for the duration of the program.