### PR TITLE
Fix CMake build and linking issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+aetherlink-fc-agent/build/

--- a/aetherlink-fc-agent/CMakeLists.txt
+++ b/aetherlink-fc-agent/CMakeLists.txt
@@ -19,4 +19,5 @@ add_executable(fc_agent
     ${PROTO_SRCS}
 )
 
-target_link_libraries(fc_agent MAVSDK::mavsdk Protobuf::libprotobuf)
+target_include_directories(fc_agent PUBLIC ${Protobuf_INCLUDE_DIRS})
+target_link_libraries(fc_agent MAVSDK::mavsdk ${Protobuf_LIBRARIES})

--- a/aetherlink-fc-agent/src/SerializationManager.h
+++ b/aetherlink-fc-agent/src/SerializationManager.h
@@ -1,7 +1,7 @@
 #ifndef SERIALIZATION_MANAGER_H
 #define SERIALIZATION_MANAGER_H
 
-#include "proto/telemetry.pb.h"
+#include "telemetry.pb.h"
 #include <mavsdk/plugins/telemetry/telemetry.h>
 #include <string>
 


### PR DESCRIPTION
This commit resolves several issues that were preventing the project from building successfully.

The main changes are:
- Modified the CMakeLists.txt to correctly link against the Protobuf library. It now uses the `${Protobuf_LIBRARIES}` and `${Protobuf_INCLUDE_DIRS}` variables instead of the modern CMake imported target, which was not being found.
- Corrected the include path for the generated Protobuf header in `src/SerializationManager.h`.
- Added the `aetherlink-fc-agent/build/` directory to the `.gitignore` file to prevent build artifacts from being committed.

These changes allow the project to be built successfully in a clean environment.